### PR TITLE
patch 251229

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -292,6 +292,9 @@ impl Board {
             let op_overlap = self.locals[op_turn] & SUB_LOOKUP[gbit as usize];
             if (my_overlap | op_overlap) & SUB_LOOKUP[gbit as usize] == SUB_LOOKUP[gbit as usize] {
                 self.global[2].set_bit(gbit);
+                if self.global[0] | self.global[1] | self.global[2] == SF {
+                    self.status = 2;
+                }
             }
         }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -317,8 +317,8 @@ pub fn eval(board: &Board) -> i32 {
     olines.reverse();
 
     /* Eval function itself */
-    score += xlines[0] + xlines[1] / 8;
-    score -= olines[0] + olines[1] / 8;
+    score += xlines[0] + xlines[1] / 4 + xlines[2] / 16 + xlines[3] / 64 + xlines[4] / 256 + xlines[5] / 1024;
+    score -= olines[0] + olines[1] / 4 + olines[2] / 16 + olines[3] / 64 + olines[4] / 256 + olines[5] / 1024;
 
     score
 }
@@ -427,8 +427,13 @@ mod tests {
     fn engine_depth_2() {
         let mut board = Board::default();
         let mut engine = Engine::default();
+        let mut cnt = 0;
         while board.status > 2 {
             let (mv, _) = engine.search(&mut board, None, Some(2));
+            cnt += 1;
+            if cnt > 81 {
+                panic!();
+            }
             board.make_move(mv);
         }
         assert_ne!(board.status, 1);


### PR DESCRIPTION
Patch note:  
- Made static evaluation function to be more aware of non-priority lines of attack;  
- Fixed bug when board status didn't change after getting draw in some cases, leading to infinite game;  
- Other minor fixes.  
